### PR TITLE
fixed undefined CopyWebpackPlugin

### DIFF
--- a/webpack.production.config.js
+++ b/webpack.production.config.js
@@ -2,6 +2,7 @@ var path = require('path');
 var webpack = require('webpack');
 var PurescriptWebpackPlugin = require('purescript-webpack-plugin');
 var HtmlWebpackPlugin = require('html-webpack-plugin');
+var CopyWebpackPlugin = require('copy-webpack-plugin');
 
 module.exports = {
   entry: [ path.join(__dirname, 'support/index.js') ],


### PR DESCRIPTION
This was causing the `build` script to fail.
